### PR TITLE
Contao 5.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "contao/core-bundle": "^4.9",
+        "contao/core-bundle": "^5",
         "symfony/config": "^4.4 || ^5.1",
         "symfony/dependency-injection": "^4.4 || ^5.1",
         "symfony/http-kernel": "^4.4 || ^5.1",

--- a/src/Controller/FrontendModule/IvmProFilterController.php
+++ b/src/Controller/FrontendModule/IvmProFilterController.php
@@ -34,7 +34,7 @@ class IvmProFilterController extends AbstractFrontendModuleController
         $this->translator = $translator;
     }
 
-    protected function getResponse(Template $template, ModuleModel $model, Request $request): ?Response
+    protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
         global $objPage;
 
@@ -134,7 +134,7 @@ class IvmProFilterController extends AbstractFrontendModuleController
                     $label = $value;
             }
             $active = false;
-            if (isset($inputFilters[$thisFilterKeys[0]])) {            
+            if (isset($inputFilters[$thisFilterKeys[0]])) {
                 $checkActive = \is_array($inputFilters[$thisFilterKeys[0]]) ? $inputFilters[$thisFilterKeys[0]][0] : $inputFilters[$thisFilterKeys[0]];
                 $active = $checkActive == $urlValue;
             }

--- a/src/Controller/FrontendModule/IvmProListController.php
+++ b/src/Controller/FrontendModule/IvmProListController.php
@@ -12,14 +12,16 @@ declare(strict_types=1);
 
 namespace Qbus\IvmProBundle\Controller\FrontendModule;
 
-use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 use Contao\Input;
-use Contao\ModuleModel;
-use Contao\PageModel;
 use Contao\Template;
-use Qbus\IvmProClient\Repository\UnitRepository;
+use Contao\PageModel;
+use Contao\ModuleModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Qbus\IvmProClient\Repository\UnitRepository;
+use Contao\CoreBundle\Exception\RedirectResponseException;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
+use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 
 class IvmProListController extends AbstractFrontendModuleController
 {
@@ -32,7 +34,7 @@ class IvmProListController extends AbstractFrontendModuleController
         $this->subdomain = $subdomain;
     }
 
-    protected function getResponse(Template $template, ModuleModel $model, Request $request): ?Response
+    protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
         $readerPage = PageModel::findByPk($model->jumpTo);
 

--- a/src/Controller/FrontendModule/IvmProListController.php
+++ b/src/Controller/FrontendModule/IvmProListController.php
@@ -12,16 +12,14 @@ declare(strict_types=1);
 
 namespace Qbus\IvmProBundle\Controller\FrontendModule;
 
+use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 use Contao\Input;
-use Contao\Template;
-use Contao\PageModel;
 use Contao\ModuleModel;
+use Contao\PageModel;
+use Contao\Template;
+use Qbus\IvmProClient\Repository\UnitRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Qbus\IvmProClient\Repository\UnitRepository;
-use Contao\CoreBundle\Exception\RedirectResponseException;
-use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
-use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 
 class IvmProListController extends AbstractFrontendModuleController
 {

--- a/src/Controller/FrontendModule/IvmProReaderController.php
+++ b/src/Controller/FrontendModule/IvmProReaderController.php
@@ -31,7 +31,7 @@ class IvmProReaderController extends AbstractFrontendModuleController
         $this->subdomain = $subdomain;
     }
 
-    protected function getResponse(Template $template, ModuleModel $model, Request $request): ?Response
+    protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
         $id = Input::get('auto_item');
 


### PR DESCRIPTION
Stellt Contao 5.6 Kompatibilität her.

- Contao core Bundle Version erhöht
- Controller Responses an AbstractFrontendModuleController angepasst
