### PR TITLE
add symfony 6.4 as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "contao/core-bundle": "^5",
-        "symfony/config": "^4.4 || ^5.1",
-        "symfony/dependency-injection": "^4.4 || ^5.1",
-        "symfony/http-kernel": "^4.4 || ^5.1",
+        "symfony/config": "^4.4 || ^5.1 || ^6.4",
+        "symfony/dependency-injection": "^4.4 || ^5.1 || ^6.4",
+        "symfony/http-kernel": "^4.4 || ^5.1 || ^6.4",
         "qbus/ivm-pro-client-contao-manager-plugin": "^0.2.0"
     },
     "conflict": {
@@ -25,7 +25,7 @@
         "contao/manager-plugin": "^2.0",
         "contao/easy-coding-standard": "^3.0",
         "phpunit/phpunit": "^8.4",
-        "symfony/phpunit-bridge": "^4.4 || ^5.1"
+        "symfony/phpunit-bridge": "^4.4 || ^5.1 || ^6.4"
     },
     "extra": {
         "contao-manager-plugin": "Qbus\\IvmProBundle\\ContaoManager\\Plugin"


### PR DESCRIPTION
Zur Behebung der contao/news-bundle Abhängigkeiten.


Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires contao/news-bundle 5.3.* -> satisfiable by contao/news-bundle[5.3.0, ..., 5.3.40].
    - Root composer.json requires qbus/contao-ivm-pro-bundle ^0.2.0 -> satisfiable by qbus/contao-ivm-pro-bundle[0.2.0].
    - contao/news-bundle[5.3.0, ..., 5.3.40] require symfony/config ^6.4 -> satisfiable by symfony/config[v6.4.0, ..., v6.4.26].
    - Conclusion: don't install symfony/config v6.4.26 (conflict analysis result)